### PR TITLE
Add 90x90 icon for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Generates all known types and sizes icons from PNG image. Uses ImageMagick.
 - `firefox-icon-48x48.png` (48x48) - Firefox on Android / Windows;
 - `firefox-icon-60x60.png` (60x60) - Firefox OS;
 - `firefox-icon-64x64.png` (64x64) - Firefox on Android / Windows;
+- `firefox-icon-90x90.png` (60x60) - Firefox OS;
 - `firefox-icon-128x128.png` (128x128) - Firefox on Android / Windows;
 - `firefox-icon-256x256.png` (256x256) - Firefox on Android / Windows.
 

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -223,7 +223,7 @@ module.exports = function(grunt) {
                         contentFirefox.icons = {};
                     }
 
-                    ['16', '30', '32', '48', '60', '64', '128', '256'].forEach(function(size) {
+                    ['16', '30', '32', '48', '60', '64', '90', '128', '256'].forEach(function(size) {
                         var dimensions = size + 'x' + size;
                         var dhalf = "circle "+size/2+","+size/2+" "+size/2+",1";
                         var fifname = "firefox-icon-" + dimensions + ".png";

--- a/test/test_stage2.js
+++ b/test/test_stage2.js
@@ -229,6 +229,23 @@ exports.favicons = {
         test.done();
     },
 
+    // firefox-icon-90x90.png exists
+    fx90Exists: function(test) {
+        test.expect(1);
+        var exists = fs.existsSync(path + "/firefox-icon-90x90.png");
+        test.ok(exists, 'firefox-icon-90x90.png does not exist.');
+        test.done();
+    },
+
+    // firefox-icon-90x90.png dimensions
+    fx90Dim: function(test) {
+        test.expect(1);
+        var dimensions = sizeOf(path + "/firefox-icon-90x90.png");
+        var pass = dimensions.width === 90 && dimensions.height === 90;
+        test.ok(pass, 'firefox-icon-90x90.png is not 90x90.');
+        test.done();
+    },
+
     // firefox-icon-128x128.png exists
     fx128Exists: function(test) {
         test.expect(1);
@@ -267,7 +284,7 @@ exports.favicons = {
     manifestsum: function(test) {
         test.expect(1);
         var original = crypto.createHash('sha1').update(grunt.file.read(path + '/manifest.webapp')).digest('hex');
-        test.ok(original === 'e4bbb42a563f9b32f565817d8f3cdbe4d6518eb3', 'firefox manifest hashsum not valid');
+        test.ok(original === '3b515fc36857866b8713c9b6958d167959d94159', 'firefox manifest hashsum not valid');
         test.done();
     },
 


### PR DESCRIPTION
The [Firefox validator](https://marketplace.firefox.com/developers/validator) complains that there is no 90x90 icons:

```
90x90px icon should be provided for Firefox OS.

Warnung: An icon of size 90x90 should be provided for the app. Firefox OS will look for this icon size before any other.
```

Couldn't find that written anywhere else, but it's a warning less. ;)
