### PR TITLE
Add Firefox icon 120x120

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Generates all known types and sizes icons from PNG image. Uses ImageMagick.
 - `firefox-icon-48x48.png` (48x48) - Firefox on Android / Windows;
 - `firefox-icon-60x60.png` (60x60) - Firefox OS;
 - `firefox-icon-64x64.png` (64x64) - Firefox on Android / Windows;
-- `firefox-icon-90x90.png` (60x60) - Firefox OS;
+- `firefox-icon-90x90.png` (90x90) - Firefox OS;
+- `firefox-icon-120x120.png` (120x120) - Firefox OS;
 - `firefox-icon-128x128.png` (128x128) - Firefox on Android / Windows;
 - `firefox-icon-256x256.png` (256x256) - Firefox on Android / Windows.
 

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -223,7 +223,7 @@ module.exports = function(grunt) {
                         contentFirefox.icons = {};
                     }
 
-                    ['16', '30', '32', '48', '60', '64', '90', '128', '256'].forEach(function(size) {
+                    ['16', '30', '32', '48', '60', '64', '90', '120', '128', '256'].forEach(function(size) {
                         var dimensions = size + 'x' + size;
                         var dhalf = "circle "+size/2+","+size/2+" "+size/2+",1";
                         var fifname = "firefox-icon-" + dimensions + ".png";

--- a/test/test_stage2.js
+++ b/test/test_stage2.js
@@ -246,6 +246,23 @@ exports.favicons = {
         test.done();
     },
 
+    // firefox-icon-120x120.png exists
+    fx120Exists: function(test) {
+        test.expect(1);
+        var exists = fs.existsSync(path + "/firefox-icon-120x120.png");
+        test.ok(exists, 'firefox-icon-120x120.png does not exist.');
+        test.done();
+    },
+
+    // firefox-icon-120x120.png dimensions
+    fx120Dim: function(test) {
+        test.expect(1);
+        var dimensions = sizeOf(path + "/firefox-icon-120x120.png");
+        var pass = dimensions.width === 120 && dimensions.height === 120;
+        test.ok(pass, 'firefox-icon-120x120.png is not 120x120.');
+        test.done();
+    },
+
     // firefox-icon-128x128.png exists
     fx128Exists: function(test) {
         test.expect(1);
@@ -284,7 +301,7 @@ exports.favicons = {
     manifestsum: function(test) {
         test.expect(1);
         var original = crypto.createHash('sha1').update(grunt.file.read(path + '/manifest.webapp')).digest('hex');
-        test.ok(original === '3b515fc36857866b8713c9b6958d167959d94159', 'firefox manifest hashsum not valid');
+        test.ok(original === '48a62081fee8bd4721f4b164bf8c5d36dd044d41', 'firefox manifest hashsum not valid');
         test.done();
     },
 


### PR DESCRIPTION
Dammit, Firefox raises a warning if this is missing, too. They could've shown that warning before next to the 90x90 warning.

But I build my app again with the 120x120 icon and now there aren't any warnings anymore.
