### PR TITLE
Added option for .ico transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ Default value: `false`
 
 Make [Android Homescreen](https://developer.chrome.com/multidevice/android/installtohomescreen) app icon.
 
+#### options.icoBackgroundColor
+Type: `String`
+Default value: `white`
+Values: `none|colorName|#COLOR`
+
+Make defined color transparent in the `favicon.ico` image.
+
 ### Low resolution
 
 If you reduce the image to 16x16, it will blured. To avoid this, you can put near source image the prefixes. For example: source image called `logo.png`. If you put nearly `logo.16x16.png` then it will be used.

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
             windowsTile: true,
             coast: false,
             sharp: 0,
+            icoBackgroundColor: "white",
             tileBlackWhite: true,
             tileColor: "auto", // none, auto, #color
             firefox: false,
@@ -177,6 +178,7 @@ module.exports = function(grunt) {
                         "-alpha on",
                         "-background none",
                         options.trueColor ? "" : "-bordercolor white -border 0 -colors 64",
+                        options.icoBackgroundColor ? "-transparent " + options.icoBackgroundColor : "",
                         path.join(f.dest, 'favicon.ico')
                     ]));
                     grunt.log.ok();


### PR DESCRIPTION
Current implementation will always return a white background for any png source with alpha channel. This option makes the defined color transparent. Ideally we'd just use the original alpha channel, but can't get it to work.
