### PR TITLE
Added option for indentation type

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,25 @@ module.exports = function(grunt) {
                 },
                 src: 'test/img.jpg',
                 dest: 'test/out'
+            },
+            stage5: {
+              options: {
+                html: 'test/out/test.html.indent',
+                trueColor: true,
+                HTMLPrefix: "/images/icons/",
+                windowsTile: false,
+                precomposed: false,
+                appleTouchBackgroundColor: "#a0b4bb",
+                appleTouchPadding: 25,
+                firefox: true,
+                sharp: 1,
+                debug: true,
+                firefoxManifest: 'test/out/manifest.webapp',
+                androidHomescreen: true,
+                indent: '  '
+              },
+              src: 'test/test.png',
+              dest: 'test/out'
             }
         },
 
@@ -88,6 +107,10 @@ module.exports = function(grunt) {
             manifest: {
                 src: 'test/manifest.webapp',
                 dest: 'test/out/manifest.webapp'
+            },
+            indent: {
+                src: 'test/index.html',
+                dest: 'test/out/test.html.indent'
             }
         },
 
@@ -95,7 +118,8 @@ module.exports = function(grunt) {
             stage1: ['test/test_stage1.js'],
             stage2: ['test/test_stage2.js'],
             stage3: ['test/test_stage3.js'],
-            stage4: ['test/test_stage4.js']
+            stage4: ['test/test_stage4.js'],
+            stage5: ['test/test_stage5.js']
         },
 
         clean: ['test/out']
@@ -112,8 +136,9 @@ module.exports = function(grunt) {
     grunt.registerTask('stage2', ['clean', 'copy', 'favicons:stage2', 'nodeunit:stage2']);
     grunt.registerTask('stage3', ['clean', 'copy:php', 'copy:manifest', 'favicons:stage3', 'nodeunit:stage3']);
     grunt.registerTask('stage4', ['clean', 'favicons:stage4', 'nodeunit:stage4']);
+    grunt.registerTask('stage5', ['clean', 'copy', 'favicons:stage5', 'nodeunit:stage5']);
 
-    grunt.registerTask('test', ['jshint', 'stage1', 'stage2', 'stage3', 'stage4', 'clean']);
+    grunt.registerTask('test', ['jshint', 'stage1', 'stage2', 'stage3', 'stage4', 'stage5', 'clean']);
     grunt.registerTask('default', ['test']);
 
 };

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ Default value: `false`
 
 Make [Android Homescreen](https://developer.chrome.com/multidevice/android/installtohomescreen) app icon.
 
+#### options.indent
+Type: `String`
+Default value: `\t`
+
+String value for the indentation to be used for each link in the resulting HTML. Defaults to a tab character.
+
 ### Low resolution
 
 If you reduce the image to 16x16, it will blured. To avoid this, you can put near source image the prefixes. For example: source image called `logo.png`. If you put nearly `logo.16x16.png` then it will be used.

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -35,7 +35,8 @@ module.exports = function(grunt) {
             regular: true,
             firefoxRound: false,
             firefoxManifest: "",
-            androidHomescreen: false
+            androidHomescreen: false,
+            indent: "\t"
         });
 
         // Execute external command
@@ -348,45 +349,45 @@ module.exports = function(grunt) {
                     var elements = "";
 
                     if (options.windowsTile) {
-                        elements += "\t<meta name=\"msapplication-square70x70logo\" content=\"" + options.HTMLPrefix + "windows-tile-70x70.png\"/>\n";
-                        elements += "\t<meta name=\"msapplication-square150x150logo\" content=\"" + options.HTMLPrefix + "windows-tile-150x150.png\"/>\n";
-                        elements += "\t<meta name=\"msapplication-square310x310logo\" content=\"" + options.HTMLPrefix + "windows-tile-310x310.png\"/>\n";
-                        elements += "\t<meta name=\"msapplication-TileImage\" content=\"" + options.HTMLPrefix + "windows-tile-144x144.png\"/>\n";
+                        elements += options.indent + "<meta name=\"msapplication-square70x70logo\" content=\"" + options.HTMLPrefix + "windows-tile-70x70.png\"/>\n";
+                        elements += options.indent + "<meta name=\"msapplication-square150x150logo\" content=\"" + options.HTMLPrefix + "windows-tile-150x150.png\"/>\n";
+                        elements += options.indent + "<meta name=\"msapplication-square310x310logo\" content=\"" + options.HTMLPrefix + "windows-tile-310x310.png\"/>\n";
+                        elements += options.indent + "<meta name=\"msapplication-TileImage\" content=\"" + options.HTMLPrefix + "windows-tile-144x144.png\"/>\n";
                         if (options.tileColor !== "none") {
-                            elements += "\t<meta name=\"msapplication-TileColor\" content=\"" + options.tileColor + "\"/>\n";
+                            elements += options.indent + "<meta name=\"msapplication-TileColor\" content=\"" + options.tileColor + "\"/>\n";
                         }
                     }
 
                     // iOS
                     if (options.apple) {
-                        elements += "\t<link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"" + options.HTMLPrefix + "apple-touch-icon-152x152-precomposed.png\">\n";
-                        elements += "\t<link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"" + options.HTMLPrefix + "apple-touch-icon-120x120-precomposed.png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"" + options.HTMLPrefix + "apple-touch-icon-152x152-precomposed.png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"" + options.HTMLPrefix + "apple-touch-icon-120x120-precomposed.png\">\n";
 
-                        elements += "\t<link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"" + options.HTMLPrefix + "apple-touch-icon-76x76-precomposed.png\">\n";
-                        elements += "\t<link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"" + options.HTMLPrefix + "apple-touch-icon-60x60-precomposed.png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"" + options.HTMLPrefix + "apple-touch-icon-76x76-precomposed.png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"" + options.HTMLPrefix + "apple-touch-icon-60x60-precomposed.png\">\n";
 
-                        elements += "\t<link rel=\"apple-touch-icon" + prefix + "\" sizes=\"144x144\" href=\"" + options.HTMLPrefix + "apple-touch-icon-144x144" + prefix + ".png\">\n";
-                        elements += "\t<link rel=\"apple-touch-icon" + prefix + "\" sizes=\"114x114\" href=\"" + options.HTMLPrefix + "apple-touch-icon-114x114" + prefix + ".png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon" + prefix + "\" sizes=\"144x144\" href=\"" + options.HTMLPrefix + "apple-touch-icon-144x144" + prefix + ".png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon" + prefix + "\" sizes=\"114x114\" href=\"" + options.HTMLPrefix + "apple-touch-icon-114x114" + prefix + ".png\">\n";
 
-                        elements += "\t<link rel=\"apple-touch-icon" + prefix + "\" sizes=\"72x72\" href=\"" + options.HTMLPrefix + "apple-touch-icon-72x72" + prefix + ".png\">\n";
-                        elements += "\t<link rel=\"apple-touch-icon\" sizes=\"57x57\" href=\"" + options.HTMLPrefix + "apple-touch-icon.png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon" + prefix + "\" sizes=\"72x72\" href=\"" + options.HTMLPrefix + "apple-touch-icon-72x72" + prefix + ".png\">\n";
+                        elements += options.indent + "<link rel=\"apple-touch-icon\" sizes=\"57x57\" href=\"" + options.HTMLPrefix + "apple-touch-icon.png\">\n";
                     }
 
                     // Coast browser
                     if (options.coast) {
-                      elements += "\t<link rel=\"icon\" sizes=\"228x228\" href=\"" + options.HTMLPrefix + "coast-icon-228x228.png\" />\n";
+                      elements += options.indent + "<link rel=\"icon\" sizes=\"228x228\" href=\"" + options.HTMLPrefix + "coast-icon-228x228.png\" />\n";
                     }
 
                     // Android Homescreen app
                     if (options.androidHomescreen) {
-                      elements += "\t<meta name=\"mobile-web-app-capable\" value=\"yes\" />\n";
-                      elements += "\t<link rel=\"icon\" sizes=\"196x196\" href=\"" + options.HTMLPrefix + "homescreen-196x196.png\" />\n";
+                      elements += options.indent + "<meta name=\"mobile-web-app-capable\" value=\"yes\" />\n";
+                      elements += options.indent + "<link rel=\"icon\" sizes=\"196x196\" href=\"" + options.HTMLPrefix + "homescreen-196x196.png\" />\n";
                     }
 
                     // Default
                     if (options.regular) {
-                        elements += "\t<link rel=\"shortcut icon\" href=\"" + options.HTMLPrefix + "favicon.ico\" />\n";
-                        elements += "\t<link rel=\"icon\" type=\"image/png\" sizes=\"64x64\" href=\"" + options.HTMLPrefix + "favicon.png\" />\n";
+                        elements += options.indent + "<link rel=\"shortcut icon\" href=\"" + options.HTMLPrefix + "favicon.ico\" />\n";
+                        elements += options.indent + "<link rel=\"icon\" type=\"image/png\" sizes=\"64x64\" href=\"" + options.HTMLPrefix + "favicon.png\" />\n";
                     }
 
                     // Windows 8 tile. In HTML version background color will be as meta-tag

--- a/test/test_stage5.js
+++ b/test/test_stage5.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var grunt = require('grunt');
+var crypto = require('crypto');
+
+var path = 'test/out';
+
+exports.favicons = {
+
+    // html test hashsum with two-space indentation
+    htmlsum: function(test) {
+        test.expect(1);
+        var original = crypto.createHash('sha1').update(grunt.file.read(path + '/test.html.indent')).digest('hex');
+        test.ok(original === 'cb5cb4fa1bd93ca4eaf73a4248719c2bd5b8b541', 'html hashsum (' + original + ') not valid');
+        test.done();
+    }
+
+};


### PR DESCRIPTION
I've added an option to allow the indentation for the links in the html to be controlled via the user.
In 0.6.4 the indentation is forced to a tab (via a `\t`), and this remains as the default, but can now be overidden with a String as part of the options. Tests included.