### PR TITLE
use sync-exec instead of execSync, fixes problem with Node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "execSync": "~1.0.1-pre",
     "cheerio": "~0.12.1"
   },
   "devDependencies": {
@@ -39,7 +38,8 @@
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
     "image-size": "~0.1.5",
-    "crypto": "0.0.3"
+    "crypto": "0.0.3",
+    "sync-exec": "^0.4.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -8,7 +8,7 @@
 
 var path = require('path');
 var fs = require('fs');
-var execSync = require("execSync");
+var exec = require("sync-exec");
 
 module.exports = function(grunt) {
 
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
             if (options.debug) {
                 console.log("\n\033[37m" + cmd + "\033[0m");
             }
-            return execSync.exec(cmd);
+            return exec(cmd);
         };
 
         // Convert image with imagemagick


### PR DESCRIPTION
As suggested in https://github.com/mgutz/execSync/issues/38#issuecomment-73771651, replacing *execSync* by *sync-exec* solves a problem occurring with Node 0.12.
Will also fix #52.