### PR TITLE
fix: update android homescreen dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Generates all known types and sizes icons from PNG image. Uses ImageMagick.
 - `firefox-icon-120x120.png` (120x120) - Firefox OS;
 - `firefox-icon-128x128.png` (128x128) - Firefox on Android / Windows;
 - `firefox-icon-256x256.png` (256x256) - Firefox on Android / Windows;
-- `homescreen-196x196.png` (196x196) - Android Homescreen.
+- `homescreen-192x192.png` (196x196) - Android Homescreen.
 
 Adds changes to `html` file.
 

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -254,8 +254,8 @@ module.exports = function(grunt) {
 
                 // Android Homescreen app
                 if (options.androidHomescreen) {
-                    grunt.log.write('homescreen-196x196.png... ');
-                    convert(combine(source, f.dest, "196x196", "homescreen-196x196.png", additionalOpts));
+                    grunt.log.write('homescreen-192x192.png... ');
+                    convert(combine(source, f.dest, "192x192", "homescreen-192x192.png", additionalOpts));
                     grunt.log.ok();
                 }
 
@@ -383,7 +383,7 @@ module.exports = function(grunt) {
                     // Android Homescreen app
                     if (options.androidHomescreen) {
                       elements += options.indent + "<meta name=\"mobile-web-app-capable\" value=\"yes\" />\n";
-                      elements += options.indent + "<link rel=\"icon\" sizes=\"196x196\" href=\"" + options.HTMLPrefix + "homescreen-196x196.png\" />\n";
+                      elements += options.indent + "<link rel=\"icon\" sizes=\"192x192\" href=\"" + options.HTMLPrefix + "homescreen-192x192.png\" />\n";
                     }
 
                     // Default

--- a/test/test_stage2.js
+++ b/test/test_stage2.js
@@ -297,20 +297,20 @@ exports.favicons = {
         test.done();
     },
 
-    // homescreen-196x196.png exists
-    ah196Exists: function(test) {
+    // homescreen-192x192.png exists
+    ah192Exists: function(test) {
         test.expect(1);
-        var exists = fs.existsSync(path + "/homescreen-196x196.png");
-        test.ok(exists, 'homescreen-196x196.png does not exist.');
+        var exists = fs.existsSync(path + "/homescreen-192x192.png");
+        test.ok(exists, 'homescreen-192x192.png does not exist.');
         test.done();
     },
 
-    // homescreen-196x196.png dimensions
+    // homescreen-192x192.png dimensions
     ah196Dim: function(test) {
         test.expect(1);
-        var dimensions = sizeOf(path + "/homescreen-196x196.png");
-        var pass = dimensions.width === 196 && dimensions.height === 196;
-        test.ok(pass, 'homescreen-196x196.png is not 196x196.');
+        var dimensions = sizeOf(path + "/homescreen-192x192.png");
+        var pass = dimensions.width === 192 && dimensions.height === 192;
+        test.ok(pass, 'homescreen-192x192.png is not 192x192.');
         test.done();
     },
 
@@ -326,7 +326,7 @@ exports.favicons = {
     htmlsum: function(test) {
         test.expect(1);
         var original = crypto.createHash('sha1').update(grunt.file.read(path + '/test.html')).digest('hex');
-        test.ok(original === 'ba907d7c29db7307b8c9045fc7c8f532efa53788', 'html hashsum not valid');
+        test.ok(original === '3de4a21225e96816a33312eb1172331257ac2837', 'html hashsum not valid');
         test.done();
     }
 

--- a/test/test_stage5.js
+++ b/test/test_stage5.js
@@ -11,7 +11,7 @@ exports.favicons = {
     htmlsum: function(test) {
         test.expect(1);
         var original = crypto.createHash('sha1').update(grunt.file.read(path + '/test.html.indent')).digest('hex');
-        test.ok(original === 'cb5cb4fa1bd93ca4eaf73a4248719c2bd5b8b541', 'html hashsum (' + original + ') not valid');
+        test.ok(original === '67503be51f9337c10dfd0a89b0202a8c17863967', 'html hashsum (' + original + ') not valid');
         test.done();
     }
 


### PR DESCRIPTION
Regarding the spec, the dimensions of a icon should be
192x192 pixel, not 196x196 pixel.

https://developer.chrome.com/multidevice/android/installtohomescreen