### PR TITLE
Add support for ieconfig.xml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Generates all known types and sizes icons from PNG image. Uses ImageMagick.
 - `apple-touch-icon-120x120.png` (120x120) — iPhone retina, iOS 7 and higher;
 - `apple-touch-icon-144x144.png` (144x144) — iPad retina;
 - `apple-touch-icon-152x152.png` (152x152) — iPad retina iOS 7;
+- `windows-tile-70x70.png` (70x70) — Windows 8 tile;
+- `windows-tile-150x150.png` (150x150) — Windows 8 tile;
+- `windows-tile-310x150.png` (310x150) — Windows 8 tile;
+- `windows-tile-310x310.png` (310x310) — Windows 8 tile;
 - `windows-tile-144x144.png` (144x144) — Windows 8 tile;
 - `coast-icon-228x228.png` (228x228) - Coast browser;
 - `firefox-icon-16x16.png` (16x16) - Firefox on Android / Windows;
@@ -33,6 +37,8 @@ Generates all known types and sizes icons from PNG image. Uses ImageMagick.
 - `homescreen-192x192.png` (196x196) - Android Homescreen.
 
 Adds changes to `html` file.
+
+Can create an `ieconfig.xml` file.
 
 ## Getting Started
 This plugin requires Grunt `~0.4.1` and ImageMagick.
@@ -93,6 +99,12 @@ Type: `String`
 Default value: `''`
 
 Path to HTML you want to add links to icons.
+
+#### options.ieconfig
+Type: `String`
+Default value: `''`
+
+Path to ieconfig.xml file you want to create.
 
 #### options.HTMLPrefix
 Type: `String`

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -107,6 +107,8 @@ module.exports = function(grunt) {
 
         // Append all icons to HTML as meta tags (needs cheerio)
         var needHTML = options.html !== undefined && options.html !== "";
+        var needIEconfig = options.ieconfig !== undefined && options.ieconfig !== "";
+        var timestamp = '?ts=' + new Date().getTime().toString();
 
         if (needHTML) {
             var cheerio = require("cheerio");
@@ -342,25 +344,53 @@ module.exports = function(grunt) {
                     convert(combine(source, f.dest, "144x144", "windows-tile-144x144.png", additionalOpts));
                     convert(combine(source, f.dest, "150x150", "windows-tile-150x150.png", additionalOpts));
                     convert(combine(source, f.dest, "310x310", "windows-tile-310x310.png", additionalOpts));
+                    if (options.tileColor !== "none") {
+                        convert(combine(source, f.dest, "310x150", "windows-tile-310x150.png", additionalOpts + ' -gravity center -background "' + options.tileColor + '" -extent 310x150 '));
+                    }
                     grunt.log.ok();
 
+                }
+
+                if (needIEconfig) {
+                    grunt.log.write('Updating IEconfig... ');
+                    var elements = "";
+
+                    elements += "<browserconfig>\n";
+                    elements += options.indent + "<msapplication>\n";
+                    elements += options.indent + options.indent + "<tile>\n";
+                    elements += options.indent + options.indent + options.indent + "<square70x70logo src=\"" + options.HTMLPrefix + "windows-tile-70x70.png\"/>\n";
+                    elements += options.indent + options.indent + options.indent + "<square150x150logo src=\"" + options.HTMLPrefix + "windows-tile-150x150.png\"/>\n";
+                    elements += options.indent + options.indent + options.indent + "<wide310x150logo src=\"" + options.HTMLPrefix + "windows-tile-310x150.png\"/>\n";
+                    elements += options.indent + options.indent + options.indent + "<square310x310logo src=\"" + options.HTMLPrefix + "windows-tile-310x310.png\"/>\n";
+                    elements += options.indent + options.indent + options.indent + "<TileColor>" + options.tileColor + "</TileColor>\n";
+                    elements += options.indent + options.indent + "</tile>>\n";
+                    elements += options.indent + "</msapplication>\n";
+                    elements += "</browserconfig>\n";
+
+                    // Saving HTML
+                    grunt.file.write(options.ieconfig, elements);
+
+                    grunt.log.ok();
                 }
 
                 // Append icons to <HEAD>
                 if (needHTML) {
                     grunt.log.write('Updating HTML... ');
-
-                    var timestamp = '?ts=' + new Date().getTime().toString();
-
                     var elements = "";
 
                     if (options.windowsTile) {
-                        elements += options.indent + "<meta name=\"msapplication-square70x70logo\" content=\"" + options.HTMLPrefix + "windows-tile-70x70.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
-                        elements += options.indent + "<meta name=\"msapplication-square150x150logo\" content=\"" + options.HTMLPrefix + "windows-tile-150x150.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
-                        elements += options.indent + "<meta name=\"msapplication-square310x310logo\" content=\"" + options.HTMLPrefix + "windows-tile-310x310.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
-                        elements += options.indent + "<meta name=\"msapplication-TileImage\" content=\"" + options.HTMLPrefix + "windows-tile-144x144.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
-                        if (options.tileColor !== "none") {
-                            elements += options.indent + "<meta name=\"msapplication-TileColor\" content=\"" + options.tileColor + "\"/>\n";
+                        if (needIEconfig) {
+                            elements += options.indent + "<meta name=\"msapplication-config\" content=\"" + options.HTMLPrefix + options.ieconfig + "\"/>\n";
+                        }
+                        else {
+                            elements += options.indent + "<meta name=\"msapplication-square70x70logo\" content=\"" + options.HTMLPrefix + "windows-tile-70x70.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
+                            elements += options.indent + "<meta name=\"msapplication-square150x150logo\" content=\"" + options.HTMLPrefix + "windows-tile-150x150.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
+                            elements += options.indent + "<meta name=\"msapplication-square310x310logo\" content=\"" + options.HTMLPrefix + "windows-tile-310x310.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
+                            elements += options.indent + "<meta name=\"msapplication-wide310x150logo\" content=\"" + options.HTMLPrefix + "windows-tile-310x150.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
+                            elements += options.indent + "<meta name=\"msapplication-TileImage\" content=\"" + options.HTMLPrefix + "windows-tile-144x144.png" + (options.timestamp ? timestamp : '') + "\"/>\n";
+                            if (options.tileColor !== "none") {
+                                elements += options.indent + "<meta name=\"msapplication-TileColor\" content=\"" + options.tileColor + "\"/>\n";
+                            }
                         }
                     }
 


### PR DESCRIPTION
This patch does the following

- generate an 310x150 windows tile
- adds an option to output an ieconfig.xml
- links the file in the html output

