### PR TITLE
Add Apple 180x180 app icon generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Generates all known types and sizes icons from PNG image. Uses ImageMagick.
 - `apple-touch-icon-120x120.png` (120x120) — iPhone retina, iOS 7 and higher;
 - `apple-touch-icon-144x144.png` (144x144) — iPad retina;
 - `apple-touch-icon-152x152.png` (152x152) — iPad retina iOS 7;
+- `apple-touch-icon-180x180.png` (180x180) — iPhone 6 Plus retina iOS 8 and higher;
 - `windows-tile-144x144.png` (144x144) — Windows 8 tile;
 - `coast-icon-228x228.png` (228x228) - Coast browser;
 - `firefox-icon-16x16.png` (16x16) - Firefox on Android / Windows;

--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -250,6 +250,11 @@ module.exports = function(grunt) {
                     grunt.log.write('apple-touch-icon-152x152-precomposed.png... ');
                     convert(combine(source, f.dest, "152x152", "apple-touch-icon-152x152-precomposed.png", additionalOpts, options.appleTouchPadding));
                     grunt.log.ok();
+
+                    // 180x180: iPhone 6 Plus retina iOS 8 and higher
+                    grunt.log.write('apple-touch-icon-180x180-precomposed.png... ');
+                    convert(combine(source, f.dest, "180x180", "apple-touch-icon-180x180-precomposed.png", additionalOpts, options.appleTouchPadding));
+                    grunt.log.ok();
                 }
 
                 // 228x228: Coast
@@ -265,7 +270,7 @@ module.exports = function(grunt) {
                     convert(combine(source, f.dest, "192x192", "homescreen-192x192.png", additionalOpts));
                     grunt.log.ok();
                 }
-                
+
                 // Android Icons app
                 if (options.androidIcons) {
                     // 36x36: LDPI


### PR DESCRIPTION
Add Apple 180x180 app icon generation for iPhone 6 Plus retina iOS 8 and higher.
