### PR TITLE
fix: Fix background transparency for ico and png

### DIFF
--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -181,7 +181,7 @@ module.exports = function(grunt) {
                         if (fs.existsSync(lowResolutionImagePath)) {
                             src = lowResolutionImagePath;
                         }
-                        convert([src, '-resize', size, saveTo]);
+                        convert(['-background none', src, '-resize', size, saveTo]);
                         files.push(saveTo);
                     });
                     grunt.log.ok();
@@ -198,7 +198,7 @@ module.exports = function(grunt) {
 
                     // 64x64 favicon.png higher priority than .ico
                     grunt.log.write('favicon.png... ');
-                    convert([source, '-resize', "64x64", path.join(f.dest, 'favicon.png')]);
+                    convert(['-background none', source, '-resize', "64x64", path.join(f.dest, 'favicon.png')]);
                     grunt.log.ok();
                 }
 
@@ -265,7 +265,7 @@ module.exports = function(grunt) {
                     convert(combine(source, f.dest, "192x192", "homescreen-192x192.png", additionalOpts));
                     grunt.log.ok();
                 }
-                
+
                 // Android Icons app
                 if (options.androidIcons) {
                     // 36x36: LDPI


### PR DESCRIPTION
When using a SVG source image, ImageMagick (v6.7.7-10) will always
apply a white background to the resulting ico and png images.

This commit adds the -transparent none argument to the convert
program to ensure that the background remains transparent.
