### PR TITLE
Add error callback for new node version

### DIFF
--- a/tasks/favicons.js
+++ b/tasks/favicons.js
@@ -265,7 +265,7 @@ module.exports = function(grunt) {
                     convert(combine(source, f.dest, "192x192", "homescreen-192x192.png", additionalOpts));
                     grunt.log.ok();
                 }
-                
+
                 // Android Icons app
                 if (options.androidIcons) {
                     // 36x36: LDPI
@@ -449,7 +449,9 @@ module.exports = function(grunt) {
                 // Cleanup
                 if (options.regular) {
                     ['16x16', '32x32', '48x48'].forEach(function(size) {
-                        fs.unlink(path.join(f.dest, size + '.png'));
+                        fs.unlink(path.join(f.dest, size + '.png'), function(error) {
+                          grunt.fail.warn(error)
+                        });
                     });
                 }
 


### PR DESCRIPTION
On node 10, a warning causes the task to fail. Adding a simple error handler fixes the issue. An alternative is to use unlinkSync instead.